### PR TITLE
Fix rsyslog build script [WORK IN PROGRESS]

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -67,9 +67,42 @@ Current Scripts
 ---------------
 The current scripts base on Adiscon's internal scripts. As such, they
 are generalized and need to be enhanced for the team effort. Everything
-is currently done on Ubuntu 14.04LTS, so package names apply to
+is currently done on Ubuntu 22.04LTS, so package names apply to
 that platform, only.
 
 They require the following prequisites:
 
 sudo apt-get install mutt devscripts debhelper dh-autoreconf cdbs
+
+Daily Builds and/or custom launchpad reposities package builds
+--------------------------------------------------------------
+Run *./scripts/daily_builds.sh* to build all libraries and rsyslog from current
+master branches and publish to launchpad.
+the default build settings.
+
+Run *./scripts/daily_builds_project.sh rsyslog* to build only one project
+from *master* branch and publish to default launchpad repository.
+
+Run *./scripts/daily_builds_project.sh rsyslog experimental* to build only one project
+from *master* branch and publish to *experimental* launchpad repository.
+
+Run *./scripts/daily_builds_project.sh rsyslog experimental v8-stable* to build only one project
+from *master* branch, use the *v8-stable* debian files and
+publish to *experimental* launchpad repository.
+
+Run *./scripts/daily_builds_project.sh rsyslog experimental/experimental v8-stable*
+to build only one project from *experimental* branch, use the *v8-stable* debian files and
+publish to *experimental* launchpad repository.
+
+Run *./scripts/daily_builds_project.sh rsyslog experimental/experimental v8-stable 20240516150808*
+to build only one project from *experimental* branch, use the *v8-stable* debian files and
+publish to *experimental* launchpad repository and overwritting the Debian version number from
+changelog with *20240516150808*. This is only needed for package developing.
+
+Build all libraries and rsyslog for a custom laucnhpad repository:
+./scripts/daily_builds_project.sh libestr experimental v8-stable
+./scripts/daily_builds_project.sh liblogging experimental v8-stable
+./scripts/daily_builds_project.sh liblognorm experimental v8-stable
+./scripts/daily_builds_project.sh libfastjson experimental v8-stable
+./scripts/daily_builds_project.sh librelp experimental v8-stable
+./scripts/daily_builds_project.sh rsyslog experimental/experimental v8-stable

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -11,7 +11,7 @@ export RS_NOTIFY_EMAIL=release-team@lists.adiscon.com
 # - the rs_infra user for the daily cron jobs
 # - it must be automatically obtained during a cron run, this is
 #   currently (badly?) solved by an empty passphrase
-export PACKAGE_SIGNING_KEY_ID=C2751450
+export PACKAGE_SIGNING_KEY_ID=60A6DC05CFD77E25BFB74F0F8B4ED6BFE8EDD305
 
 # which PPA to put to?
 export PPA=ppa:adiscon

--- a/scripts/daily_builds.sh
+++ b/scripts/daily_builds.sh
@@ -4,12 +4,12 @@ source $RSI_SCRIPTS/config.sh
 # we need to call different files for the subprojects. These are
 # mostly identical, but have important small differences. At a later
 # stage, we may want to unify this.
-$RSI_SCRIPTS/daily_tarball_libfastjson.sh
-$RSI_SCRIPTS/daily_tarball_libgt.sh
-$RSI_SCRIPTS/daily_tarball_libksi.sh
+# $RSI_SCRIPTS/daily_tarball_libgt.sh
+# $RSI_SCRIPTS/daily_tarball_libksi.sh
 $RSI_SCRIPTS/daily_tarball_libestr.sh
 $RSI_SCRIPTS/daily_tarball_liblogging.sh
 $RSI_SCRIPTS/daily_tarball_liblognorm.sh
+$RSI_SCRIPTS/daily_tarball_libfastjson.sh
 $RSI_SCRIPTS/daily_tarball_librelp.sh
 $RSI_SCRIPTS/daily_tarball_rsyslog.sh
 

--- a/scripts/daily_builds_project.sh
+++ b/scripts/daily_builds_project.sh
@@ -1,0 +1,52 @@
+#! /bin/bash
+source $RSI_SCRIPTS/config.sh
+
+PROJECT=$1	# Samples:	libestr liblogging libfastjson liblognorm librelp rsyslog
+PPAREPO=$2	# Samples:	daily-stable 
+		#		experimental 
+		#		experimental/experimental
+PPABRANCH=$3	# Samples:	v8-stable 
+		#		master
+CUSTOMBUILD=$4	# Append needed for rebuilds to make unique upload files
+
+# Check if PROJECT is set
+if [ -z "$PROJECT" ]; then
+    echo "Error: PROJECT is not set."
+    exit 1
+fi
+
+# Check if PPAREPO is set
+if [ -z "$PPAREPO" ]; then
+    echo "Error: PPAREPO is not set."
+    exit 1
+fi
+
+# Check if PPABRANCH is set
+if [ -z "$PPABRANCH" ]; then
+    echo "Error: PPABRANCH is not set."
+    exit 1
+fi
+
+# Split PPAREPO into PPAREPO and GITBRANCH if it contains a slash
+if [[ "$PPAREPO" == */* ]]; then
+    IFS='/' read -r PPAREPO GITBRANCH <<< "$PPAREPO"
+else
+    GITBRANCH=""
+fi
+
+# Print the values for verification
+echo "DAILY BUILD PROJECT FOR: $PROJECT"
+echo "PPAREPO: $PPAREPO"
+echo "GITBRANCH: $GITBRANCH"
+echo "CUSTOMBUILD: $CUSTOMBUILD"
+
+# Build Package
+$RSI_SCRIPTS/daily_tarball_$PROJECT.sh $GITBRANCH $CUSTOMBUILD
+
+#  Get tar.gz from 
+cd $INFRAHOME/repo/$PROJECT
+TARFILE=`ls *.tar.gz`
+echo Generated TARFILE: $TARFILE
+
+# Initiate package build
+$INFRAHOME/repo/rsyslog-pkg-ubuntu/scripts/auto_daily.sh $PROJECT $PPAREPO $PPABRANCH $CUSTOMBUILD

--- a/scripts/daily_tarball_libestr.sh
+++ b/scripts/daily_tarball_libestr.sh
@@ -2,13 +2,22 @@
 # Copyright (C) 2015 by Rainer Gerhards. Released under ASL 2.0
 source $RSI_SCRIPTS/config.sh
 
+# Support custom branch
+GITBRANCH=${1:-"master"}
+echo Get DAILY TARBALL for RSYSLOG branch $GITBRANCH
+
 cd $INFRAHOME/repo/libestr
+git reset --hard
+git pull --all
+
+echo pre checkout
 make distclean
-git checkout -f master
+git checkout -f $GITBRANCH
 if [ $? -ne 0 ]; then
     git checkout master |& mutt -s "libestr tarball: git checkout failed!" $RS_NOTIFY_EMAIL
     exit 1
 fi
+echo pre pull
 git pull
 if [ $? -ne 0 ]; then
     git pull |& mutt -s "libestr tarball: git pull failed!" $RS_NOTIFY_EMAIL
@@ -18,6 +27,7 @@ fi
 # we need to rename the version
 rm *.tar.gz
 sed s/\\.master\]/\\.`git log --pretty=format:'%H' -n 1|cut -c 1-12`\]/ < configure.ac > configure.ac.new
+sed s/\\.master\]/\\.`git log --pretty=format:'%H' -n 1|cut -c 1-12`'~'`date +%Y%m%d%H%M%S`\]/ < configure.ac > configure.ac.new
 mv configure.ac.new configure.ac
 
 autoreconf -fvi && ./configure --prefix=$INFRAHOME/local && make || exit $?
@@ -46,4 +56,4 @@ echo tarfile for upload: $TARFILE
 #scp -p $TARFILE download.rsyslog.com:/home/adisconweb/www/wordpress-mu/wp-content/blogs.dir/11/files/download/rsyslog/libestr-daily.tar.gz
 
 # reset version number changes
-git checkout -f master
+git checkout -f $GITBRANCH

--- a/scripts/daily_tarball_libfastjson.sh
+++ b/scripts/daily_tarball_libfastjson.sh
@@ -1,14 +1,23 @@
 #! /bin/bash
+# Copyright (C) 2015 by Rainer Gerhards. Released under ASL 2.0
 source $RSI_SCRIPTS/config.sh 
 
+# Support custom branch
+GITBRANCH=${1:-"master"}
+echo Get DAILY TARBALL for RSYSLOG branch $GITBRANCH
+
 cd $INFRAHOME/repo/libfastjson
+git reset --hard
+git pull --all
+
+echo pre checkout
 make distclean
-git pull
-git checkout -f master
+git checkout -f $GITBRANCH
 if [ $? -ne 0 ]; then
     git checkout master |& mutt -s "libfastjson tarball: git checkout failed!" $RS_NOTIFY_EMAIL
     exit 1
 fi
+echo pre pull
 git pull
 if [ $? -ne 0 ]; then
     git pull |& mutt -s "libfastjson tarball: git pull failed!" $RS_NOTIFY_EMAIL 
@@ -46,4 +55,4 @@ echo tarfile for upload: $TARFILE
 #scp -p $TARFILE download.rsyslog.com:/home/adisconweb/www/wordpress-mu/wp-content/blogs.dir/11/files/download/rsyslog/liblognorm-daily.tar.gz
 
 # reset version number changes
-git checkout -f master
+git checkout -f $GITBRANCH

--- a/scripts/daily_tarball_libgt.sh
+++ b/scripts/daily_tarball_libgt.sh
@@ -1,13 +1,23 @@
 #! /bin/bash
+# Copyright (C) 2015 by Rainer Gerhards. Released under ASL 2.0
 source $RSI_SCRIPTS/config.sh
 
+# Support custom branch
+GITBRANCH=${1:-"master"}
+echo Get DAILY TARBALL for RSYSLOG branch $GITBRANCH
+
 cd $INFRAHOME/repo/libgt
+git reset --hard
+git pull --all
+
+echo pre checkout
 make distclean
-git checkout -f master
+git checkout -f $GITBRANCH
 if [ $? -ne 0 ]; then
     git checkout master |& mutt -s "libgt tarball: git checkout failed!" $RS_NOTIFY_EMAIL
     exit 1
 fi
+echo pre pull
 git pull
 if [ $? -ne 0 ]; then
     git pull |& mutt -s "libgt tarball: git pull failed!" $RS_NOTIFY_EMAIL
@@ -45,5 +55,4 @@ echo tarfile for upload: $TARFILE
 #scp -p $TARFILE download.rsyslog.com:/home/adisconweb/www/wordpress-mu/wp-content/blogs.dir/11/files/download/rsyslog/libgt-daily.tar.gz
 
 # reset version number changes
-git checkout -f master
-
+git checkout -f $GITBRANCH

--- a/scripts/daily_tarball_liblognorm.sh
+++ b/scripts/daily_tarball_liblognorm.sh
@@ -1,14 +1,23 @@
 #! /bin/bash
+# Copyright (C) 2015 by Rainer Gerhards. Released under ASL 2.0
 source $RSI_SCRIPTS/config.sh 
 
+# Support custom branch
+GITBRANCH=${1:-"master"}
+echo Get DAILY TARBALL for RSYSLOG branch $GITBRANCH
+
 cd $INFRAHOME/repo/liblognorm
+git reset --hard
+git pull --all
+
+echo pre checkout
 make distclean
-git pull
-git checkout -f master
+git checkout -f $GITBRANCH
 if [ $? -ne 0 ]; then
     git checkout master |& mutt -s "liblognorm tarball: git checkout failed!" $RS_NOTIFY_EMAIL
     exit 1
 fi
+echo pre pull
 git pull
 if [ $? -ne 0 ]; then
     git pull |& mutt -s "liblognorm tarball: git pull failed!" $RS_NOTIFY_EMAIL 
@@ -46,4 +55,4 @@ echo tarfile for upload: $TARFILE
 #scp -p $TARFILE download.rsyslog.com:/home/adisconweb/www/wordpress-mu/wp-content/blogs.dir/11/files/download/rsyslog/liblognorm-daily.tar.gz
 
 # reset version number changes
-git checkout -f master
+git checkout -f $GITBRANCH

--- a/scripts/daily_tarball_librelp.sh
+++ b/scripts/daily_tarball_librelp.sh
@@ -1,13 +1,23 @@
 #! /bin/bash
+# Copyright (C) 2015 by Rainer Gerhards. Released under ASL 2.0
 source $RSI_SCRIPTS/config.sh
 
+# Support custom branch
+GITBRANCH=${1:-"master"}
+echo Get DAILY TARBALL for RSYSLOG branch $GITBRANCH
+
 cd $INFRAHOME/repo/librelp
+git reset --hard
+git pull --all
+
+echo pre checkout
 make distclean
-git checkout -f master
+git checkout -f $GITBRANCH
 if [ $? -ne 0 ]; then
     git checkout master |& mutt -s "librelp tarball: git checkout failed!" $RS_NOTIY_EMAIL
     exit 1
 fi
+echo pre pull
 git pull
 if [ $? -ne 0 ]; then
     git pull |& mutt -s "librelp tarball: git pull failed!" $RS_NOTIFY_EMAIL
@@ -45,4 +55,4 @@ echo tarfile for upload: $TARFILE
 #scp -p $TARFILE download.rsyslog.com:/home/adisconweb/www/wordpress-mu/wp-content/blogs.dir/11/files/download/rsyslog/librelp-daily.tar.gz
 
 # reset version number changes
-git checkout -f master
+git checkout -f $GITBRANCH

--- a/scripts/daily_tarball_rsyslog.sh
+++ b/scripts/daily_tarball_rsyslog.sh
@@ -2,10 +2,24 @@
 echo check buildenv
 source $RSI_SCRIPTS/config.sh
 
+# Support custom branch
+GITBRANCH=${1:-"master"}
+echo Get DAILY TARBALL for RSYSLOG branch $GITBRANCH
+
+CUSTOMBUILD=${2:-""}
+
+# Prepend an underscore if CUSTOMBUILD is not empty
+if [ -n "$CUSTOMBUILD" ]; then
+    CUSTOMBUILD="_$CUSTOMBUILD"
+fi
+echo CUSTOMBUILD if any: $CUSTOMBUILD
+
 cd $INFRAHOME/repo/rsyslog
 git reset --hard
+git pull --all
+
 echo pre checkout
-git checkout -f master
+git checkout -f $GITBRANCH
 if [ $? -ne 0 ]; then
     git pull |& mutt -s "rsyslog tarball: git checkout failed!" $RS_NOTIFY_EMAIL
     exit 1
@@ -25,7 +39,7 @@ autoreconf -vfi
 ./configure
 
 # we need to rename the version
-sed -i s/\\.master\]/\\.`git log --pretty=format:'%H' -n 1|cut -c 1-12`\]/g configure.ac
+sed -i s/\\.master\]/\\.`git log --pretty=format:'%H' -n 1|cut -c 1-12`$CUSTOMBUILD\]/g configure.ac
 
 # We need to add tar-ustar to AM_INIT_AUTOMAKE! Fixed error with "tar: file name is too long (max 99)"
 sed -i 's/AM_INIT_AUTOMAKE(\[subdir-objects\])/AM_INIT_AUTOMAKE([subdir-objects 1.9 tar-ustar])/g' configure.ac
@@ -55,4 +69,4 @@ echo tarfile for upload: $TARFILE
 #scp -p $TARFILE download.rsyslog.com:/home/adisconweb/www/wordpress-mu/wp-content/blogs.dir/11/files/download/rsyslog/rsyslog-daily.tar.gz
 
 # reset version number changes
-git checkout -f master
+git checkout -f $GITBRANCH


### PR DESCRIPTION
Fix build system for new daily-stable ubuntu package branch
    
    - make dist clean before make dist
    - Use AM_INIT_AUTOMAKE([subdir-objects 1.9 tar-ustar]) in configure.ac to add tar posix support fixing issues with filenames above 99 characters.
    - updated PGPKey
    - updated / fixed scripts to build on current major Ubuntu versions
    - added script to test single package updates
    - added Ubuntu 20.04 and 22.04 support
    - added doc for new script options
    - added support for custom launchpad repositories
    - added support to build for custom git branches
